### PR TITLE
Add support for setting the MAC address

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,32 @@ Wired Ethernet connections are monitored for Internet connectivity if a default
 gateway is available. When internet-connected, they are preferred over all other
 network technologies even when the others provide default gateways.
 
+## Setting the MAC address
+
+On some devices, you'll get a random Ethernet MAC address by default and need to
+read a real MAC address out of an EEPROM. VintageNet can help with this by
+calling a function to read the MAC address at the right time. You can also force
+a MAC address if a configuration if you want to allow users to change it on the
+fly.
+
+Here's an example where the MAC address is set via a callback function:
+
+```elixir
+   {"eth0",
+      %{
+        type: VintageNetEthernet,
+        mac_address: {MyMacAddressReader, :read, []},
+        ipv4: %{method: :dhcp}
+      }}
+```
+
+`MyMacAddress.read/0` is expected to return a string of the form
+`"11:22:33:44:55:66"`. Any other return value or raising an exception will cause
+VintageNet to skip setting the MAC address.
+
+Instead of supplying an MFA tuple, you can specify a string for the
+`:mac_address` key.
+
 ## Properties
 
 There are no wired Ethernet-specific properties. See `vintage_net` for the

--- a/lib/vintage_net_ethernet.ex
+++ b/lib/vintage_net_ethernet.ex
@@ -1,8 +1,11 @@
 defmodule VintageNetEthernet do
   @behaviour VintageNet.Technology
 
+  require Logger
+
   alias VintageNet.Interface.RawConfig
   alias VintageNet.IP.{DhcpdConfig, IPv4Config}
+  alias VintageNetEthernet.MacAddress
 
   @moduledoc """
   Support for common wired Ethernet interface configurations
@@ -13,6 +16,10 @@ defmodule VintageNetEthernet do
   * `:ipv4` - IPv4 options. See VintageNet.IP.IPv4Config.
   * `:dhcpd` - DHCP daemon options if running a static IP configuration. See
     VintageNet.IP.DhcpdConfig.
+  * `:mac_address` - A MAC address string or an MFA tuple. VintageNet will set
+    the MAC address of the network interface to the value specified. If an MFA
+    tuple is passed, VintageNet will `apply` it and use the return value as the
+    address.
 
   An example DHCP configuration is:
 
@@ -38,9 +45,23 @@ defmodule VintageNetEthernet do
   @impl VintageNet.Technology
   def normalize(%{type: __MODULE__} = config) do
     config
+    |> normalize_mac_address()
     |> IPv4Config.normalize()
     |> DhcpdConfig.normalize()
   end
+
+  defp normalize_mac_address(%{mac_address: mac_address} = config) do
+    if MacAddress.valid?(mac_address) or mfa?(mac_address) do
+      config
+    else
+      raise ArgumentError, "Invalid MAC address #{inspect(mac_address)}"
+    end
+  end
+
+  defp normalize_mac_address(config), do: config
+
+  defp mfa?({m, f, a}) when is_atom(m) and is_atom(f) and is_list(a), do: true
+  defp mfa?(_), do: false
 
   @impl VintageNet.Technology
   def to_raw_config(ifname, %{type: __MODULE__} = config, opts) do
@@ -52,9 +73,37 @@ defmodule VintageNetEthernet do
       source_config: normalized_config,
       required_ifnames: [ifname]
     }
+    |> add_mac_address_config(normalized_config)
     |> IPv4Config.add_config(normalized_config, opts)
     |> DhcpdConfig.add_config(normalized_config, opts)
   end
+
+  defp add_mac_address_config(raw_config, %{mac_address: mac_address}) do
+    resolved_mac = resolve_mac(mac_address)
+
+    if MacAddress.valid?(resolved_mac) do
+      new_up_cmds =
+        raw_config.up_cmds ++
+          [{:run, "ip", ["link", "set", raw_config.ifname, "address", resolved_mac]}]
+
+      %{raw_config | up_cmds: new_up_cmds}
+    else
+      Logger.warn("vintage_net_ethernet: ignoring invalid MAC address '#{inspect(resolved_mac)}'")
+      raw_config
+    end
+  end
+
+  defp add_mac_address_config(raw_config, _config) do
+    raw_config
+  end
+
+  defp resolve_mac({m, f, a}) do
+    apply(m, f, a)
+  rescue
+    e -> {:error, e}
+  end
+
+  defp resolve_mac(mac_address), do: mac_address
 
   @impl VintageNet.Technology
   def ioctl(_ifname, _command, _args) do

--- a/lib/vintage_net_ethernet/mac_address.ex
+++ b/lib/vintage_net_ethernet/mac_address.ex
@@ -1,0 +1,61 @@
+defmodule VintageNetEthernet.MacAddress do
+  @moduledoc """
+  MAC Address utilities
+  """
+
+  @typedoc """
+  A MAC address is a string of the form "aa:bb:cc:dd:ee:ff"
+  """
+  @type t() :: <<_::136>>
+
+  @doc """
+  Return true if this is a valid MAC address
+  """
+  @spec valid?(any()) :: boolean()
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
+  def valid?(<<a, b, ?:, c, d, ?:, e, f, ?:, g, h, ?:, i, j, ?:, k, l>>) do
+    valid_hex?(a) and
+      valid_hex?(b) and
+      valid_hex?(c) and
+      valid_hex?(d) and
+      valid_hex?(e) and
+      valid_hex?(f) and
+      valid_hex?(g) and
+      valid_hex?(h) and
+      valid_hex?(i) and
+      valid_hex?(j) and
+      valid_hex?(k) and
+      valid_hex?(l)
+  end
+
+  def valid?(_), do: false
+
+  defp valid_hex?(a)
+       when a in [
+              ?0,
+              ?1,
+              ?2,
+              ?3,
+              ?4,
+              ?5,
+              ?6,
+              ?7,
+              ?8,
+              ?9,
+              ?a,
+              ?A,
+              ?b,
+              ?B,
+              ?c,
+              ?C,
+              ?d,
+              ?D,
+              ?e,
+              ?E,
+              ?f,
+              ?F
+            ],
+       do: true
+
+  defp valid_hex?(_), do: false
+end

--- a/test/vintage_net_ethernet/mac_address_test.exs
+++ b/test/vintage_net_ethernet/mac_address_test.exs
@@ -1,0 +1,20 @@
+defmodule VintageNetEthernet.MacAddressTest do
+  use ExUnit.Case
+
+  alias VintageNetEthernet.MacAddress
+
+  describe "valid?/1" do
+    test "good mac addresses" do
+      assert MacAddress.valid?("01:23:45:67:89:AB")
+      assert MacAddress.valid?("aA:bB:cC:dD:eE:fF")
+    end
+
+    test "bad mac addresses" do
+      refute MacAddress.valid?("")
+      refute MacAddress.valid?("192.168.1.1")
+      refute MacAddress.valid?({1, 2, 3})
+      refute MacAddress.valid?("g0:23:45:67:89:AB")
+      refute MacAddress.valid?("01.23.45.67.89.AB")
+    end
+  end
+end


### PR DESCRIPTION
This adds a `:mac_address` parameter that can be set to either a string
or MFA tuple. When specified, VintageNet will set the MAC address on the
network interface before bringing the interface up.

Here's an example configuration:

```elixir
{"eth0",
  %{
    type: VintageNetEthernet,
    mac_address: {MyMacAddressReader, :read, []},
    ipv4: %{method: :dhcp}
  }}
```

In the example, VintageNet calls `MyMacaddressReader.read()` for the MAC
address.
