### PR TITLE
Start cookbook and quick_configure

### DIFF
--- a/lib/vintage_net_ethernet.ex
+++ b/lib/vintage_net_ethernet.ex
@@ -5,6 +5,7 @@ defmodule VintageNetEthernet do
 
   alias VintageNet.Interface.RawConfig
   alias VintageNet.IP.{DhcpdConfig, IPv4Config}
+  alias VintageNetEthernet.Cookbook
   alias VintageNetEthernet.MacAddress
 
   @moduledoc """
@@ -114,5 +115,12 @@ defmodule VintageNetEthernet do
   def check_system(_opts) do
     # TODO
     :ok
+  end
+
+  @spec quick_configure(VintageNet.ifname()) :: :ok | {:error, term()}
+  def quick_configure(ifname \\ "eth0") do
+    with {:ok, config} <- Cookbook.dynamic_ipv4() do
+      VintageNet.configure(ifname, config)
+    end
   end
 end

--- a/lib/vintage_net_ethernet/cookbook.ex
+++ b/lib/vintage_net_ethernet/cookbook.ex
@@ -1,0 +1,13 @@
+defmodule VintageNetEthernet.Cookbook do
+  @moduledoc """
+  Recipes for common wired Ethernet configurations
+  """
+
+  @doc """
+  Return a configuration for connecting to Ethernet network with a DHCP server
+  """
+  @spec dynamic_ipv4() :: {:ok, %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}}
+  def dynamic_ipv4() do
+    {:ok, %{type: VintageNetEthernet, ipv4: %{method: :dhcp}}}
+  end
+end

--- a/test/vintage_net_ethernet/cookbook_test.exs
+++ b/test/vintage_net_ethernet/cookbook_test.exs
@@ -1,0 +1,13 @@
+defmodule VintageNetEthernet.CookbookTest do
+  use ExUnit.Case
+
+  alias VintageNetEthernet.Cookbook
+
+  test "dynamic_ipv4/0" do
+    assert {:ok,
+            %{
+              type: VintageNetEthernet,
+              ipv4: %{method: :dhcp}
+            }} == Cookbook.dynamic_ipv4()
+  end
+end


### PR DESCRIPTION
Other VintageNet implementations have these. I temporarily forgot the
IPv4 DHCP config today, and this would have helped.

The intention is to add more.
