### PR TITLE
Bump minimum VintageNet to 0.12 and Elixir to 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,28 +67,6 @@ jobs:
       - run: mix deps.get
       - run: mix test
 
-  build_elixir_1_10_otp_23:
-    docker:
-      - image: hexpm/elixir:1.10.4-erlang-23.3.4-alpine-3.13.3
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix test
-
-  build_elixir_1_9_otp_22:
-    docker:
-      - image: hexpm/elixir:1.9.4-erlang-22.3.4.18-alpine-3.13.3
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_hex_rebar
-      - <<: *install_system_deps
-      - run: mix deps.get
-      - run: mix test
-
 workflows:
   version: 2
   build_test:
@@ -96,5 +74,3 @@ workflows:
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23
-      - build_elixir_1_10_otp_23
-      - build_elixir_1_9_otp_22

--- a/.credo.exs
+++ b/.credo.exs
@@ -1,13 +1,16 @@
-# config/.credo.exs
+# .credo.exs
 %{
   configs: [
     %{
       name: "default",
+      strict: true,
       checks: [
         {Credo.Check.Refactor.MapInto, false},
         {Credo.Check.Warning.LazyLogging, false},
         {Credo.Check.Readability.LargeNumbers, only_greater_than: 86400},
-        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, parens: true}
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, parens: true},
+        {Credo.Check.Readability.Specs, tags: []},
+        {Credo.Check.Readability.StrictModuleLayout, tags: []}
       ]
     }
   ]

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # Overrides for unit tests:
 #

--- a/lib/vintage_net/technology/ethernet.ex
+++ b/lib/vintage_net/technology/ethernet.ex
@@ -1,12 +1,12 @@
 defmodule VintageNet.Technology.Ethernet do
-  @behaviour VintageNet.Technology
-
   @moduledoc """
   Deprecated - Use VintageNetEthernet now
 
   This module will automatically redirect your configurations to VintageNetEthernet so
   no changes are needed to your code. New code should use the new module.
   """
+  @behaviour VintageNet.Technology
+
   @impl VintageNet.Technology
   def normalize(%{type: __MODULE__} = config) do
     config

--- a/lib/vintage_net_ethernet.ex
+++ b/lib/vintage_net_ethernet.ex
@@ -1,13 +1,4 @@
 defmodule VintageNetEthernet do
-  @behaviour VintageNet.Technology
-
-  require Logger
-
-  alias VintageNet.Interface.RawConfig
-  alias VintageNet.IP.{DhcpdConfig, IPv4Config}
-  alias VintageNetEthernet.Cookbook
-  alias VintageNetEthernet.MacAddress
-
   @moduledoc """
   Support for common wired Ethernet interface configurations
 
@@ -42,6 +33,14 @@ defmodule VintageNetEthernet do
   }
   ```
   """
+  @behaviour VintageNet.Technology
+
+  alias VintageNet.Interface.RawConfig
+  alias VintageNet.IP.{DhcpdConfig, IPv4Config}
+  alias VintageNetEthernet.Cookbook
+  alias VintageNetEthernet.MacAddress
+
+  require Logger
 
   @impl VintageNet.Technology
   def normalize(%{type: __MODULE__} = config) do

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule VintageNetEthernet.MixProject do
     [
       app: :vintage_net_ethernet,
       version: @version,
-      elixir: "~> 1.9",
+      elixir: "~> 1.11",
       test_coverage: [tool: ExCoveralls],
       start_permanent: Mix.env() == :prod,
       build_embedded: true,
@@ -53,7 +53,7 @@ defmodule VintageNetEthernet.MixProject do
 
   defp deps do
     [
-      {:vintage_net, "~> 0.10.0 or ~> 0.11.0 or ~> 0.12.0"},
+      {:vintage_net, "~> 0.12.0"},
       {:credo, "~> 1.2", only: :test, runtime: false},
       {:dialyxir, "~> 1.1", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.22", only: :docs, runtime: false},

--- a/test/vintage_net_ethernet_test.exs
+++ b/test/vintage_net_ethernet_test.exs
@@ -98,6 +98,7 @@ defmodule VintageNetEthernetTest do
   end
 
   @doc false
+  @spec return_a_mac() :: String.t()
   def return_a_mac() do
     "12:34:56:78:9a:bc"
   end
@@ -137,6 +138,7 @@ defmodule VintageNetEthernetTest do
   end
 
   @doc false
+  @spec crash_a_mac() :: no_return()
   def crash_a_mac() do
     raise RuntimeError, "crash_a_mac"
   end


### PR DESCRIPTION
To simplify support for VintageNetEthernet, this removes support for
older Elixir and VintageNet versions just in case there are subtle
issues.
